### PR TITLE
Fix a possible crash with pathForClassName

### DIFF
--- a/Pod/Classes/MRGArchitectJSONLoader.m
+++ b/Pod/Classes/MRGArchitectJSONLoader.m
@@ -155,9 +155,8 @@ NSString * const MRGArchitectActionPrefix = @"@";
 }
 
 - (NSString *)pathForClassName:(NSString *)className suffix:(NSString *)suffix {
-    NSString *path = [[NSBundle bundleForClass:NSClassFromString(className)] resourcePath];
-    path = [path stringByAppendingPathComponent:[NSString stringWithFormat:@"%@%@.json", className, suffix ?: @""]];
-    
+    NSString *path = [[NSBundle mainBundle] pathForResource:[NSString stringWithFormat:@"%@%@", className, suffix ?: @""] ofType:@"json"];
+
     return [self fileExistsAtPath:path] ? path : nil;
 }
 


### PR DESCRIPTION
## 📖 Description

Modification to avoid a possible crash with the method "- (NSString *)pathForClassName:(NSString *)className suffix:(NSString *)suffix".

## ⚠️ Problem

In some Swift project build with Xcode 10, a crash can occur when MRGArchitect is initialized with the `MRGArchitect(for: )` method. 

The crash looks like this:

```
(lldb) po [NSBundle bundleForClass:(NSString *)NSClassFromString(className)]
error: Execution was interrupted, reason: EXC_BAD_ACCESS (code=1, address=0x20).
The process has been returned to the state before expression evaluation.
```

## 🔎 Causes

Sometimes, the call to `NSClassFromString` can returns `nil`.

With code generated with XCode 10, `NSBundle bundleForClass` crashes when the `class` parameter is `nil`.

With code generated with Xcode 9, `NSBundle bundleForClass` returns the `.app` folder when the `class` parameter is `nil`.

## 🤓 Solution

I replaced `NSBundle bundleForClass` with `NSBundle pathForResource` to fix the crash.