### PR TITLE
Fix a regression with pathForClassName behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # * http://www.objc.io/issue-6/travis-ci.html
 # * https://github.com/supermarin/xcpretty#usage
 
-osx_image: xcode7
+osx_image: xcode10.1
 language: objective-c
 # cache: cocoapods
 # podfile: Example/Podfile
@@ -12,5 +12,5 @@ language: objective-c
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
-- set -o pipefail && xcodebuild test -workspace Example/MRGArchitect.xcworkspace -scheme MRGArchitect_Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
+- set -o pipefail && xcodebuild test -workspace Example/MRGArchitect.xcworkspace -scheme MRGArchitect_Example -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.4' ONLY_ACTIVE_ARCH=NO | xcpretty -c
 - pod lib lint --quick

--- a/Example/MRGArchitect.xcodeproj/project.pbxproj
+++ b/Example/MRGArchitect.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "MRGArchitect/MRGArchitect-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -615,6 +616,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "MRGArchitect/MRGArchitect-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Example/MRGArchitect.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/MRGArchitect.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/MRGArchitect/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/MRGArchitect/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -59,6 +79,16 @@
       "idiom" : "ipad",
       "size" : "76x76",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/MRGArchitect/MRGView.swift
+++ b/Example/MRGArchitect/MRGView.swift
@@ -38,12 +38,12 @@ import UIKit
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        self.architect = MRGArchitect(forObject: self)
+        self.architect = MRGArchitect(for: self)
     }
     
-    override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         self.architect.traitCollection = self.traitCollection
-        titleLabel.text = String(format: "%@", self.architect.stringForKey("title"))
+        titleLabel.text = String(format: "%@", self.architect.string(forKey: "title"))
         self.setNeedsLayout()
     }
 }

--- a/Pod/Classes/MRGArchitectJSONLoader.m
+++ b/Pod/Classes/MRGArchitectJSONLoader.m
@@ -155,7 +155,7 @@ NSString * const MRGArchitectActionPrefix = @"@";
 }
 
 - (NSString *)pathForClassName:(NSString *)className suffix:(NSString *)suffix {
-    NSString *path = [[NSBundle mainBundle] pathForResource:[NSString stringWithFormat:@"%@%@", className, suffix ?: @""] ofType:@"json"];
+    NSString *path = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@%@.json", className, suffix ?: @""]];
 
     return [self fileExistsAtPath:path] ? path : nil;
 }


### PR DESCRIPTION
## 📖 Description

Fix a regression with `pathForClassName` behaviour.

## ⚠️ Problem

When an alternate `.json` files using `~` suffix is used, a crash can occur when a value is defined in the base file, but not in the alternate file.

## 🔎 Causes

The problem is cased by the `pathForResource: ofType:` call. 

When the path list is prepared, the first file analyzed will be the base file file (ex.: `View.json`).
When an alternate file is defined (ex.: `View~ipad.json`), the call to `pathForResource: ofType:` will return the path of the alternate file (`View~ipad.json`) even if the call was:

```objective-c
[NSBundle mainBundle] pathForResource:@"View" ofType:@"json"];
```

## 🤓 Solution

To fix the regression, I create the path without calling `bundleForClass:`.