### PR TITLE
Cache loaded architect files in JSONLoader

### DIFF
--- a/Pod/Classes/MRGArchitect.m
+++ b/Pod/Classes/MRGArchitect.m
@@ -74,7 +74,8 @@ static UIColor *MRGUIColorWithHexString(NSString *hexString) {
 }
 
 + (void)clearCache {
-    [[self architectCache] removeAllObjects];
+    [self.architectCache removeAllObjects];
+    [MRGArchitectJSONLoader clearCache];
 }
 
 + (instancetype)architectForObject:(NSObject *)object {

--- a/Pod/Classes/MRGArchitectJSONLoader.h
+++ b/Pod/Classes/MRGArchitectJSONLoader.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MRGArchitectJSONLoader : NSObject <MRGArchitectLoader>
 
++ (void)clearCache;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Setting trait collection in MRGArchitect triggers a reload of the architect file from disk, bypassing the cache of architect instances.

This is a simple fix of caching the dictionary created from the architect file loaded from disk.