### PR TITLE
Adding 896h support for iphone

### DIFF
--- a/Pod/Classes/MRGArchitectJSONLoader.m
+++ b/Pod/Classes/MRGArchitectJSONLoader.m
@@ -149,6 +149,18 @@ NSString * const MRGArchitectActionPrefix = @"@";
                     [paths addObject:path];
                 }
             }
+            
+            if (896.0f <= screenHeight) {
+                path = [self pathForClassName:className suffix:@"-896h"];
+                if ([path length] > 0) {
+                    [paths addObject:path];
+                }
+                
+                path = [self pathForClassName:className suffix:@"-896h~iphone"];
+                if ([path length] > 0) {
+                    [paths addObject:path];
+                }
+            }
             break;
         }
             

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Here is the order it will search for files on iPhone :
 - `<name>-736h~iphone.json`
 - `<name>-812h.json`
 - `<name>-812h~iphone.json`
+- `<name>-896h.json`
+- `<name>-896h~iphone.json`
 
 On iPad :
 - `<name>.json`


### PR DESCRIPTION
Adding 896h support for iphone 11, iphone 11 Pro Max , etc. (https://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions)